### PR TITLE
修复验证令牌缓存失效的bug

### DIFF
--- a/asapi/authorize_handle.go
+++ b/asapi/authorize_handle.go
@@ -419,7 +419,7 @@ func (ah *AuthorizeHandle) VerifyTokenV2(token string) (*VerifyTokenInfo, *Error
 		return nil, result
 	}
 	if ah.cfg.IsEnabledCache && ah.cfg.CacheGCInterval < resData.ExpiresIn {
-		ah.cache.Set(token, resData, time.Duration(resData.ExpiresIn-ah.cfg.CacheGCInterval)*time.Second)
+		ah.cache.Set(token, &resData, time.Duration(resData.ExpiresIn-ah.cfg.CacheGCInterval)*time.Second)
 	}
 	return &resData, nil
 }


### PR DESCRIPTION
错误的将结构体存放到缓存而非指针，导致从缓存中查找时断言失败